### PR TITLE
FIX Mac build

### DIFF
--- a/crates/llama_cpp_sys/build.rs
+++ b/crates/llama_cpp_sys/build.rs
@@ -156,8 +156,8 @@ fn push_common_flags(cx: &mut Build, cxx: &mut Build) {
         if cfg!(target_family = "unix") {
             // cx.flag("-mavx512vnni").flag("-mfp16-format=ieee");
             // cxx.flag("-mavx512vnni").flag("-mfp16-format=ieee");
-            cx.flag("-mavx512vnni")
-            cxx.flag("-mavx512vnni")
+            cx.flag("-mavx512vnni");
+            cxx.flag("-mavx512vnni");
         } else if cfg!(target_family = "windows") {
             cx.define("__ARM_NEON", None)
                 .define("__ARM_FEATURE_FMA", None)

--- a/crates/llama_cpp_sys/build.rs
+++ b/crates/llama_cpp_sys/build.rs
@@ -154,8 +154,10 @@ fn push_common_flags(cx: &mut Build, cxx: &mut Build) {
 
     if cfg!(any(target_arch = "arm", target_arch = "aarch64")) {
         if cfg!(target_family = "unix") {
-            cx.flag("-mavx512vnni").flag("-mfp16-format=ieee");
-            cxx.flag("-mavx512vnni").flag("-mfp16-format=ieee");
+            // cx.flag("-mavx512vnni").flag("-mfp16-format=ieee");
+            // cxx.flag("-mavx512vnni").flag("-mfp16-format=ieee");
+            cx.flag("-mavx512vnni")
+            cxx.flag("-mavx512vnni")
         } else if cfg!(target_family = "windows") {
             cx.define("__ARM_NEON", None)
                 .define("__ARM_FEATURE_FMA", None)

--- a/crates/llama_cpp_sys/build.rs
+++ b/crates/llama_cpp_sys/build.rs
@@ -156,8 +156,6 @@ fn push_common_flags(cx: &mut Build, cxx: &mut Build) {
         if cfg!(target_family = "unix") {
             // cx.flag("-mavx512vnni").flag("-mfp16-format=ieee");
             // cxx.flag("-mavx512vnni").flag("-mfp16-format=ieee");
-            cx.flag("-mavx512vnni");
-            cxx.flag("-mavx512vnni");
         } else if cfg!(target_family = "windows") {
             cx.define("__ARM_NEON", None)
                 .define("__ARM_FEATURE_FMA", None)


### PR DESCRIPTION
# What does this PR do? 

This PR fixes `metal` build indirectly. I am trying out your rust bindings on my mac and i ran into an issue when building for `metal`. I did some research and found this llama.cpp issue https://github.com/ggerganov/llama.cpp/pull/3086/files
I have no idea about c++ but notice that the `-mfp16-format=ieee` should not be added when building on a mac arm. 

Maybe you can look into this. Happy to work on this if you have some pointers. 