### PR TITLE
Add ability to truncate and set the context of a LlamaSession.

### DIFF
--- a/crates/llama_cpp/src/standard_sampler.rs
+++ b/crates/llama_cpp/src/standard_sampler.rs
@@ -75,6 +75,7 @@ pub struct StandardSampler {
 impl StandardSampler {}
 
 impl Sampler for StandardSampler {
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     fn sample(
         &self,
         context: *mut llama_context,


### PR DESCRIPTION
Currently, the only way one can modify the context in a LlamaSession is to append new tokens to the end. This pr adds the `truncate_context` method to trim tokens from the end of context, and the `set_context` methods to set the value of the entire context. 

`set_context` can be much more efficient than creating a new LlamaSession and calling `advance_context` because it reuses the kv-cache for tokens in the shared prefix of the new context and the old context.

I have done some limited testing on this, and it has run without error so far.