### PR TITLE
Add LlamaSession::deep_copy method

### DIFF
--- a/crates/llama_cpp/src/model/mod.rs
+++ b/crates/llama_cpp/src/model/mod.rs
@@ -327,7 +327,7 @@ impl LlamaModel {
         &self,
         session_params: SessionParams,
     ) -> Result<LlamaSession, LlamaContextError> {
-        let params = llama_context_params::from(session_params);
+        let params = llama_context_params::from(session_params.clone());
         let max_batch = params.n_batch;
 
         let ctx = unsafe {
@@ -346,6 +346,7 @@ impl LlamaModel {
                 tokens: Mutex::new(Vec::new()),
                 last_batch_size: AtomicUsize::new(0),
                 max_batch,
+                params: session_params,
             }),
         })
     }

--- a/crates/llama_cpp/src/session/mod.rs
+++ b/crates/llama_cpp/src/session/mod.rs
@@ -471,7 +471,7 @@ impl LlamaSession {
             assert_eq!(copy_size, set_size);
         }
 
-        *copy.inner.tokens.blocking_lock() = self.inner.tokens.blocking_lock().clone();
+        *block_on(copy.inner.tokens.write()) = block_on(self.inner.tokens.read()).clone();
         copy.inner.last_batch_size.store(
             self.inner.last_batch_size.load(Ordering::SeqCst),
             Ordering::SeqCst,

--- a/crates/llama_cpp/src/session/mod.rs
+++ b/crates/llama_cpp/src/session/mod.rs
@@ -60,6 +60,7 @@ pub struct LlamaSession {
 }
 
 /// The cloned part of a [`LlamaSession`].
+// NOTE: Changes made here may need to be reflected in LlamaSession::deep_copy
 pub(crate) struct LlamaSessionInner {
     /// The model this session was created from.
     pub(crate) model: LlamaModel,
@@ -348,6 +349,11 @@ impl LlamaSession {
         self.inner.model.clone()
     }
 
+    /// Returns the parameters this session was created with.
+    pub fn params(&self) -> &SessionParams {
+        &self.inner.params
+    }
+
     /// Returns the number of tokens currently in this session's context
     pub fn context_size(&self) -> usize {
         block_on(self.inner.tokens.read()).len()
@@ -471,6 +477,8 @@ impl LlamaSession {
             assert_eq!(copy_size, set_size);
         }
 
+        // NOTE: Any changes to the fields of a LlamaSession may require that
+        // those changes are mirrored here
         *block_on(copy.inner.tokens.write()) = block_on(self.inner.tokens.read()).clone();
         copy.inner.last_batch_size.store(
             self.inner.last_batch_size.load(Ordering::SeqCst),

--- a/crates/llama_cpp/src/session/params.rs
+++ b/crates/llama_cpp/src/session/params.rs
@@ -5,6 +5,7 @@ use std::ptr;
 use llama_cpp_sys::{ggml_type, llama_context_default_params, llama_context_params};
 
 /// Session-specific parameters.
+#[derive(Clone)]
 pub struct SessionParams {
     /// RNG seed, [`u32::MAX`] for random (default)
     pub seed: u32,


### PR DESCRIPTION
Adds a method to `LlamaSession` that creates a new `LlamaSession` with the same context. I've done little bit of testing on this, but nothing very extensive.