### PR TITLE
Remove RwLock from LlamaModel

### DIFF
--- a/crates/llama_cpp/src/session/completion.rs
+++ b/crates/llama_cpp/src/session/completion.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use futures::{executor::block_on, Stream};
-use tokio::sync::mpsc::{error::TryRecvError, UnboundedReceiver};
+use tokio::sync::mpsc::UnboundedReceiver;
 
 use crate::{LlamaModel, Token};
 


### PR DESCRIPTION
Fixes #41 by removing RwLock from the internals of LlamaModel. This is correct because `RwLock::write` and its varients were never called, making it equivalent to a `Box`.