### PR TITLE
Add remove_tokens_in_range method

### DIFF
--- a/crates/llama_cpp/src/session/mod.rs
+++ b/crates/llama_cpp/src/session/mod.rs
@@ -377,6 +377,9 @@ impl LlamaSession {
     /// Removes all tokens within the given range without performing any prompt
     /// processing. If you remove tokens in the middle of context, it is recommended that you keep
     /// the first ~4 tokens of context when you do this, per <https://arxiv.org/abs/2309.17453>.
+    ///
+    /// Note that calling this is not equivalent to calling [`LlamaSession::set_context`] with the
+    /// same list of tokens that this method produces.
     pub fn remove_tokens_in_range(&mut self, range: impl RangeBounds<usize>) {
         let start_bound = match range.start_bound() {
             Bound::Included(i) => *i as i32,


### PR DESCRIPTION
Partially resolves #36 by adding a method that allows end users to remove tokens in the middle of context. There isn't currently a solution to automatically truncate context when it gets too long, but this does allow end users to implement their own solutions to this problem.