### PR TITLE
Fix #53; replace beam search with greedy sampling

### DIFF
--- a/crates/llama_cpp/src/detail.rs
+++ b/crates/llama_cpp/src/detail.rs
@@ -5,72 +5,13 @@
 #![allow(non_snake_case)]
 
 use std::ffi::{c_char, c_void, CStr};
-use std::ptr::slice_from_raw_parts;
 
-use tokio::sync::mpsc::UnboundedSender;
 use tracing::{error, info, trace, warn};
 
 use llama_cpp_sys::{
     ggml_log_level, ggml_log_level_GGML_LOG_LEVEL_ERROR, ggml_log_level_GGML_LOG_LEVEL_INFO,
-    ggml_log_level_GGML_LOG_LEVEL_WARN, llama_beams_state,
+    ggml_log_level_GGML_LOG_LEVEL_WARN,
 };
-
-use crate::Token;
-
-pub(crate) struct BeamSearchState {
-    pub(crate) tx: UnboundedSender<Token>,
-}
-
-#[no_mangle]
-pub(crate) unsafe extern "C" fn llama_beam_search_callback(
-    shared_state_ptr: *mut c_void,
-    beam_state: llama_beams_state,
-) {
-    let shared_state = unsafe {
-        // SAFETY: `channel` has this type and hasn't been de-allocated.
-        &mut *(shared_state_ptr as *mut BeamSearchState)
-    };
-
-    if shared_state.tx.is_closed() {
-        // Close all beams to terminate the search.
-        for i in 0..beam_state.n_beams {
-            unsafe {
-                // SAFETY: beam_views[i] exists where 0 <= i <= n_beams.
-                *beam_state.beam_views.add(i)
-            }
-            .eob = true;
-        }
-    }
-
-    // Llama.cpp trims the common prefix after every invocation; the presence of
-    // `common_prefix_length > 0` means the first `common_prefix_length` tokens have been
-    // settled upon.
-    if beam_state.common_prefix_length > 0 {
-        let first_beam = unsafe {
-            // SAFETY: At least one beam always exists.
-            &*(beam_state.beam_views)
-        };
-
-        let beam_tokens = unsafe {
-            // SAFETY: If all beams share a common prefix, at least that many tokens exist in
-            // every beam.
-            &*slice_from_raw_parts(first_beam.tokens, beam_state.common_prefix_length)
-        };
-
-        for unshared_token in beam_tokens {
-            let _ = shared_state.tx.send(Token(*unshared_token));
-        }
-    }
-
-    if beam_state.last_call {
-        unsafe {
-            // SAFETY: `channel` is heap-allocated, and this is the only time we'll construct
-            // a `Box` back over it; this is the last time this function will be called, and
-            // the last time this pointer will be seen.
-            let _ = Box::from_raw(shared_state);
-        }
-    }
-}
 
 #[no_mangle]
 pub(crate) unsafe extern "C" fn llama_log_callback(

--- a/crates/llama_cpp/src/model/mod.rs
+++ b/crates/llama_cpp/src/model/mod.rs
@@ -9,7 +9,6 @@ use std::sync::{atomic::AtomicUsize, Arc, Mutex, RwLock};
 use std::usize;
 
 use derive_more::{Deref, DerefMut};
-use futures::executor::block_on;
 use thiserror::Error;
 use tracing::{error, info, trace, warn};
 
@@ -165,7 +164,7 @@ impl LlamaModel {
         file_path: impl AsRef<Path>,
         model_params: LlamaParams,
     ) -> Result<Self, LlamaLoadError> {
-        let backend_ref = block_on(BackendRef::new());
+        let backend_ref = BackendRef::new();
         info!("Loading model \"{}\"", file_path.as_ref().to_string_lossy());
 
         let file_path = file_path.as_ref();

--- a/crates/llama_cpp/src/model/mod.rs
+++ b/crates/llama_cpp/src/model/mod.rs
@@ -5,14 +5,12 @@ use std::cmp::min;
 use std::ffi::{c_char, CStr, CString};
 use std::path::{Path, PathBuf};
 use std::ptr::slice_from_raw_parts;
-use std::sync::{atomic::AtomicUsize, Arc};
+use std::sync::{atomic::AtomicUsize, Arc, Mutex, RwLock};
 use std::usize;
 
 use derive_more::{Deref, DerefMut};
 use futures::executor::block_on;
 use thiserror::Error;
-use tokio::sync::Mutex;
-use tokio::sync::RwLock;
 use tracing::{error, info, trace, warn};
 
 use backend::BackendRef;

--- a/crates/llama_cpp/src/session/completion.rs
+++ b/crates/llama_cpp/src/session/completion.rs
@@ -6,7 +6,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use futures::{executor::block_on, Stream};
+use futures::Stream;
 use tokio::sync::mpsc::UnboundedReceiver;
 
 use crate::{LlamaModel, Token};
@@ -26,7 +26,7 @@ impl CompletionHandle {
     /// Blocks the current thread, resolving to the next completed token, or `None` if EOS is
     /// reached.
     pub fn next_token(&mut self) -> Option<Token> {
-        block_on(self.rx.recv())
+        tokio::task::block_in_place(|| self.rx.blocking_recv())
     }
 
     /// Asynchronously yields the current thread, resolving to the next completed token, or `None`
@@ -78,7 +78,7 @@ impl Iterator for CompletionHandle {
     type Item = Token;
 
     fn next(&mut self) -> Option<Self::Item> {
-        block_on(self.rx.recv())
+        self.next_token()
     }
 }
 

--- a/crates/llama_cpp/src/standard_sampler.rs
+++ b/crates/llama_cpp/src/standard_sampler.rs
@@ -296,10 +296,7 @@ impl StandardSampler {
     ///
     /// Ensures that at least `min_keep` tokens remain after the
     /// [`SamplerStage`]'s are applied.
-    pub fn new_softmax(
-        stages: Vec<SamplerStage>,
-        min_keep: usize,
-    ) -> StandardSampler {
+    pub fn new_softmax(stages: Vec<SamplerStage>, min_keep: usize) -> StandardSampler {
         StandardSampler {
             stages,
             min_keep,


### PR DESCRIPTION
Fixes #53. Changes all mutexes/rwlocks to their blocking std counterparts and uses `tokio::task::block_in_place` so we can call `UnboundedReceiver::blocking_recv` in an async context.

Furthermore, replaces the beam search of `LlamaSession::start_completing` with a call to `LlamaSession::start_completing_with` with a greedy sampler and `max_predictions` as the number of unused tokens in context. I did this because I'm fairly sure that the beam search wasn't working correctly and was not updating `LlamaSessionInner.tokens` correctly.